### PR TITLE
푸시 관련 및 게임 기능 버그들 수정

### DIFF
--- a/Project/WA/Source/WA/PlayerCamera.cpp
+++ b/Project/WA/Source/WA/PlayerCamera.cpp
@@ -24,9 +24,12 @@ void APlayerCamera::Tick(float DeltaTime)
 
 	if (playerCharacter)
 	{
+		FVector target_pos = playerCharacter->GetActorLocation() + relativeLocation;
+		target_pos.Z = relativeLocation.Z;	// 높이 고정
+		
 		SetActorLocation(FMath::Lerp(
 			GetActorLocation(), 
-			playerCharacter->GetActorLocation() + relativeLocation, 
+			target_pos, 
 			DeltaTime * speedLevel));
 
 		// 회전 상태가 다를 때에만 회전

--- a/Project/WA/Source/WA/PlayerCharacter.cpp
+++ b/Project/WA/Source/WA/PlayerCharacter.cpp
@@ -108,8 +108,7 @@ float APlayerCharacter::TakeDamage(float Damage, struct FDamageEvent const& Dama
 		health_point -= Damage;
 
 		// 넉백
-		// 단순 뒤로 이동도 좋고, ForwardVector 기준으로 반대 방향에 목적지 잡아놓고 선형보간 연산으로 이동시키는 것도 좋다.
-		// 지속시간은 invincible과 동일. 이동을 금지해야 하므로 state 변경이 필요하며, Tick에 내용 구현이 이루어져야 한다.
+		MoveDashEnd();	// state를 IDLE로 만드므로, KnockBack으로 만들기 전에 선언되어야 함
 		state = ECharacterState::KnockBack;
 		velocity = GetActorForwardVector() * -knockBack_speed;
 	}
@@ -135,17 +134,7 @@ void APlayerCharacter::Tick(float DeltaTime)
 		cur_dashTime += DeltaTime;
 		if (cur_dashTime >= dash_time)	// Dash 종료
 		{
-			cur_dashCount--;
-			cur_dashTime = 0.0f;
-			cur_dashCooltime = 0.0f;
-
-			// 최대 이동 속도 원상 복귀
-			GetCharacterMovement()->MaxWalkSpeed = move_speed;
-			GetCharacterMovement()->MaxAcceleration = move_accel;
-			// 중력 다시 활성화
-			GetCharacterMovement()->GravityScale = 1.0f;
-
-			state = ECharacterState::Idle;
+			MoveDashEnd();
 		}
 	}
 	// Dash 쿨다운 진행

--- a/Project/WA/Source/WA/PlayerCharacter.cpp
+++ b/Project/WA/Source/WA/PlayerCharacter.cpp
@@ -61,6 +61,12 @@ void APlayerCharacter::BeginPlay()
 	GetCharacterMovement()->MaxWalkSpeed = move_speed;
 	GetCharacterMovement()->MaxAcceleration = move_accel;
 	GetCharacterMovement()->JumpZVelocity = jump_power;
+
+	AWAGameModeBase* WaGMB = (AWAGameModeBase*)(GetWorld()->GetAuthGameMode());
+	if (WaGMB)
+	{
+		WaGMB->SetRespawnPoint(GetActorLocation());
+	}
 }
 
 void APlayerCharacter::Landed(const FHitResult& Hit)
@@ -199,8 +205,11 @@ void APlayerCharacter::InputForwardBackward(float value)
 	switch (state)
 	{
 	case ECharacterState::Idle:
-		velocity.X = value;
-		AddMovementInput(velocity.GetSafeNormal());
+		if (!isblockForwardBackwardMove)
+		{
+			velocity.X = value;
+			AddMovementInput(velocity.GetSafeNormal());
+		}
 		break;
 	case ECharacterState::Shooting:
 		break;
@@ -211,8 +220,11 @@ void APlayerCharacter::InputLeftRight(float value)
 	switch (state)
 	{
 	case ECharacterState::Idle:
-		velocity.Y = value;
-		AddMovementInput(velocity.GetSafeNormal());
+		if (!isblockLeftRightMove)
+		{
+			velocity.Y = value;
+			AddMovementInput(velocity.GetSafeNormal());
+		}
 		break;
 	case ECharacterState::Shooting:
 		break;
@@ -264,8 +276,9 @@ void APlayerCharacter::Death()
 {
 	// ÃÊ±âÈ­
 	//UE_LOG(LogTemp, Warning, TEXT("Character has dead..."));
-	((AWAGameModeBase*)(GetWorld()->GetAuthGameMode()))->RoomReset();
-	SetActorLocation(FVector(50.0f, 30.0f, 325.0f));
+	AWAGameModeBase* WaGMB = (AWAGameModeBase*)(GetWorld()->GetAuthGameMode());
+	WaGMB->RoomReset();
+	SetActorLocation(WaGMB->GetRespawnPoint());
 
 	health_point = 3;
 
@@ -325,4 +338,12 @@ void APlayerCharacter::DecreaseDashCount(int decrease_num)
 APlayerCamera* APlayerCharacter::GetPlayerCamera() const
 {
 	return playerCamera;
+}
+
+void APlayerCharacter::SetBlockPlayerMoveDirection(bool isHorizon, bool value)
+{
+	if (isHorizon)
+		isblockLeftRightMove = value;
+	else
+		isblockForwardBackwardMove = value;
 }

--- a/Project/WA/Source/WA/PlayerCharacter.cpp
+++ b/Project/WA/Source/WA/PlayerCharacter.cpp
@@ -31,7 +31,7 @@ APlayerCharacter::APlayerCharacter()
 	dash_cooldown = 3.0f;
 	dash_count = 0;
 
-	knockBack_speed = 2.0f;
+	knockBack_speed = 5000.0f;
 	knockBack_decrease = 0.01f;
 
 	camera_init = false;
@@ -167,7 +167,7 @@ void APlayerCharacter::Tick(float DeltaTime)
 		}
 
 		velocity *= (1.0f - knockBack_decrease);
-		SetActorLocation(GetActorLocation() + velocity);
+		GetCharacterMovement()->AddImpulse(velocity);
 	}
 
 	// 아래로 떨어지면 사망

--- a/Project/WA/Source/WA/PlayerCharacter.h
+++ b/Project/WA/Source/WA/PlayerCharacter.h
@@ -100,6 +100,9 @@ private:
 	// 현재 경과된 무적 시간(피격 지속 시간)
 	float cur_invincibleTime;
 
+	bool isblockLeftRightMove;
+	bool isblockForwardBackwardMove;
+
 
 	void InputForwardBackward(float value);
 	void InputLeftRight(float value);
@@ -120,4 +123,6 @@ public:
 	void DecreaseDashCount(int decrease_num);
 
 	APlayerCamera* GetPlayerCamera() const;
+
+	void SetBlockPlayerMoveDirection(bool isHorizon, bool value);
 };


### PR DESCRIPTION
- 묘령의 잘린 코드 복구. 정상 작동 확인
- 캐릭터가 점프 시 카메라가 캐릭터의 고도를 따라가던 문제 해결. 아무도 몰랐음 ㅋㅋ
- 캐릭터 대시 중 피격 시, 피격 종료 후 대시 속도가 유지되는 문제 해결
- 캐릭터가 넉백될 경우, 강제 이동에 의해 벽을 뚫을 수 있던 문제 해결

- 추후 해당 브랜치에서 추가적으로 Spike에 막히는 문제와 ViewChanger 중첩 적용 시 의도대로 작동하지 않는 문제 해결 예정
  * Spike에 캐릭터가 막히는 문제는 단순히 BP_Spike의 가시 StaticMesh의 Collision을 NoCollision으로 바꾸면 해결됨
  * ViewChanger 중첩 적용 문제는 좀 더 생각해볼 예정